### PR TITLE
Add commands for inspecting/changing shuffle/repeat state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Install `npm i -g @svrooij/sonos-cli` and start using, see below.
 This sonos cli, is just a cli wrapper around the [sonos-ts](https://github.com/svrooij/node-sonos-ts) library. I could use some support in both :wink:. If you like this library please tell me on [twitter](https://twitter.com/svrooij), or start [sponsoring][link_sponsor] me.
 
 <!-- toc -->
+* [@svrooij/sonos-cli](#svrooijsonos-cli)
 * [Usage](#usage)
 * [Commands](#commands)
 <!-- tocstop -->
@@ -34,7 +35,7 @@ $ npm install -g @svrooij/sonos-cli
 $ sonos COMMAND
 running command...
 $ sonos (-v|--version|version)
-@svrooij/sonos-cli/0.0.0-development win32-x64 node-v16.15.1
+@svrooij/sonos-cli/0.0.0-development darwin-arm64 node-v16.13.1
 $ sonos --help [COMMAND]
 USAGE
   $ sonos COMMAND
@@ -130,8 +131,8 @@ USAGE
 ARGUMENTS
   DEVICE   Name or uuid of player
 
-  COMMAND  (play|pause|next|previous|toggle|stop|volumeup|volumedown|mute|unmute|togglemute) What command do you want to
-           send
+  COMMAND  (play|pause|next|previous|toggle|stop|volumeup|volumedown|mute|unmute|togglemute|repeatall|repeatone|repeatof
+           f|togglerepeat|shuffleon|shuffleoff|toggleshuffle) What command do you want to send
 
 OPTIONS
   -h, --help       Show CLI help.
@@ -195,7 +196,7 @@ USAGE
 
 ARGUMENTS
   DEVICE  Name or uuid of player
-  KIND    (attributes|media|position|transport|queue|volume) What do you want to load
+  KIND    (attributes|media|settings|position|transport|queue|volume|repeat|shuffle) What do you want to load
 
 OPTIONS
   -h, --help       Show CLI help.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oclif/plugin-help": "^5.1.12",
         "@oclif/plugin-not-found": "^2.3.1",
         "@oclif/plugin-version": "^1",
-        "@svrooij/sonos": "2.5.0",
+        "@svrooij/sonos": "2.6.0-beta.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       },
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/@svrooij/sonos": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@svrooij/sonos/-/sonos-2.5.0.tgz",
-      "integrity": "sha512-QcRJRo9aILj5/6ikebQsGZL9kqGP9Er6XyWJG5akHI0XIALMk/kLyXVrAnYZ2jef3Hj2GCCHCqCNkbAIqCZ53Q==",
+      "version": "2.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@svrooij/sonos/-/sonos-2.6.0-beta.1.tgz",
+      "integrity": "sha512-VqioQMMEyJ7GJbkMklwuLTWYrO4Y5/kM8NyfdKV4sRkQyOOYHl7f/XrU2Q/CAp1BZ9CDukX/g5r80gT9Vzk4cA==",
       "dependencies": {
         "debug": "4.3.1",
         "fast-xml-parser": "3.19.0",
@@ -7976,9 +7976,9 @@
       }
     },
     "@svrooij/sonos": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@svrooij/sonos/-/sonos-2.5.0.tgz",
-      "integrity": "sha512-QcRJRo9aILj5/6ikebQsGZL9kqGP9Er6XyWJG5akHI0XIALMk/kLyXVrAnYZ2jef3Hj2GCCHCqCNkbAIqCZ53Q==",
+      "version": "2.6.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@svrooij/sonos/-/sonos-2.6.0-beta.1.tgz",
+      "integrity": "sha512-VqioQMMEyJ7GJbkMklwuLTWYrO4Y5/kM8NyfdKV4sRkQyOOYHl7f/XrU2Q/CAp1BZ9CDukX/g5r80gT9Vzk4cA==",
       "requires": {
         "debug": "4.3.1",
         "fast-xml-parser": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@oclif/plugin-help": "^5.1.12",
     "@oclif/plugin-not-found": "^2.3.1",
     "@oclif/plugin-version": "^1",
-    "@svrooij/sonos": "2.5.0",
+    "@svrooij/sonos": "2.6.0-beta.1",
     "fs-extra": "^10.1.0",
     "tslib": "^2.4.0"
   },
@@ -56,8 +56,12 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "sonos",
-    "additionalHelpFlags": ["-h"],
-    "additionalVersionFlags": ["-v"],
+    "additionalHelpFlags": [
+      "-h"
+    ],
+    "additionalVersionFlags": [
+      "-v"
+    ],
     "plugins": [
       "@oclif/plugin-help",
       "@oclif/plugin-not-found"

--- a/src/commands/control.ts
+++ b/src/commands/control.ts
@@ -1,4 +1,5 @@
 import {Command, Flags} from '@oclif/core'
+import {Repeat} from '@svrooij/sonos/lib/models'
 import SonosCommandHelper from '../helpers/sonos-command-helper'
 
 export default class Control extends Command {
@@ -12,12 +13,27 @@ export default class Control extends Command {
   static args = [
     {name: 'device', required: true, description: 'Name or uuid of player'},
     {name: 'command', required: true, description: 'What command do you want to send',
-      options: ['play', 'pause', 'next', 'previous', 'toggle', 'stop', 'volumeup', 'volumedown', 'mute', 'unmute', 'togglemute']},
+      options: ['play', 'pause', 'next', 'previous', 'toggle', 'stop', 'volumeup', 'volumedown', 'mute', 'unmute', 'togglemute', 'repeatall', 'repeatone', 'repeatoff', 'togglerepeat', 'shuffleon', 'shuffleoff', 'toggleshuffle']},
   ]
 
   async run(): Promise<void> {
     const {args, flags} = await this.parse(Control)
     const device = await SonosCommandHelper.device(this, flags, args.device)
+
+    async function toggleRepeat(): Promise<void> {
+      const repeat = await device.GetRepeat()
+      switch (repeat) {
+      case Repeat.Off:
+        await device.SetRepeat(Repeat.RepeatAll)
+        break
+      case Repeat.RepeatAll:
+        await device.SetRepeat(Repeat.RepeatOne)
+        break
+      case Repeat.RepeatOne:
+        await device.SetRepeat(Repeat.Off)
+        break
+      }
+    }
 
     switch (args.command) {
     case 'play':
@@ -55,6 +71,28 @@ export default class Control extends Command {
       await device.RenderingControlService.SetMute({InstanceID: 0, Channel: 'Master', DesiredMute: !muteResponse.CurrentMute})
       break
     }
+
+    case 'repeatall':
+      await device.SetRepeat(Repeat.RepeatAll)
+      break
+    case 'repeatone':
+      await device.SetRepeat(Repeat.RepeatOne)
+      break
+    case 'repeatoff':
+      await device.SetRepeat(Repeat.Off)
+      break
+    case 'togglerepeat':
+      await toggleRepeat()
+      break
+    case 'shuffleon':
+      await device.SetShuffle(true)
+      break
+    case 'shuffleoff':
+      await device.SetShuffle(false)
+      break
+    case 'toggleshuffle':
+      await device.SetShuffle(!await device.GetShuffle())
+      break
     }
   }
 }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -11,7 +11,7 @@ export default class Info extends Command {
 
   static args = [
     {name: 'device', required: true, description: 'Name or uuid of player'},
-    {name: 'kind', description: 'What do you want to load', required: true, options: ['attributes', 'media', 'position',  'transport', 'queue', 'volume']},
+    {name: 'kind', description: 'What do you want to load', required: true, options: ['attributes', 'media', 'settings', 'position',  'transport', 'queue', 'volume', 'repeat', 'shuffle']},
   ]
 
   async run(): Promise<void> {
@@ -35,6 +35,15 @@ export default class Info extends Command {
       break
     case 'volume':
       this.log('Current volume %d', (await device.RenderingControlService.GetVolume({InstanceID: 0, Channel: 'Master'})).CurrentVolume)
+      break
+    case 'settings':
+      CliUx.ux.styledJSON(await device.AVTransportService.GetTransportSettings({InstanceID: 0}))
+      break
+    case 'repeat':
+      CliUx.ux.styledJSON({repeat: await device.GetRepeat()})
+      break
+    case 'shuffle':
+      CliUx.ux.styledJSON({shuffle: await device.GetShuffle()})
       break
     }
 


### PR DESCRIPTION
Adds the following commands:

```bash
$ sonos info Speaker settings     
{
  "PlayMode": "REPEAT_ONE",
  "RecQualityMode": "NOT_IMPLEMENTED"
}
```

```
$ sonos control Speaker repeatall # sets Speaker to Repeat All
$ sonos control Speaker repeatone # sets Speaker to Repeat One
$ sonos control Speaker repeatoff # sets Speaker to No Repeats
$ sonos control Speaker togglerepeat # cycles Speaker from No Repeats -> Repeat All -> Repeat One -> No Repeats

$ sonos control Speaker shuffleon # sets Speaker to shuffle
$ sonos control Speaker shuffleoff # sets Speaker to not shuffle
$ sonos control Speaker toggleshuffle # toggles Speaker from shuffle to not shuffle
```